### PR TITLE
[Feature] FloorManager 구현

### DIFF
--- a/Assets/Scripts/GameEvents.cs
+++ b/Assets/Scripts/GameEvents.cs
@@ -1,0 +1,9 @@
+using System;
+using UnityEngine;
+
+public static class GameEvents
+{
+    public static Action<Transform> OnRoomTransition;
+    public static Action OnRoomClear;
+    public static Action OnPlayerHit;
+}

--- a/Assets/Scripts/Map/FloorManager.cs
+++ b/Assets/Scripts/Map/FloorManager.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FloorManager : MonoBehaviour
+{
+    [SerializeField] private List<RoomData> _roomDataList;
+    [SerializeField] private float _roomSpacing = 20f;
+    [SerializeField] private int _totalRooms = 10;
+
+    private Dictionary<Vector2Int, RoomController> _rooms = new();
+    private RoomController _currentRoom;
+
+    private void Start()
+    {
+        GenerateFloor();
+    }
+
+    private void GenerateFloor()
+    {
+        var generator = new MapGenerator(_totalRooms);
+        var nodes = generator.Generate();
+
+        foreach (var node in nodes)
+        {
+            var data = GetRoomData(node.RoomType);
+            if (data?.Prefab == null) continue;
+
+            var worldPos = new Vector3(node.GridPosition.x, 0, node.GridPosition.y) * _roomSpacing;
+            var instance = Instantiate(data.Prefab, worldPos, Quaternion.identity, transform);
+
+            var controller = instance.GetComponent<RoomController>();
+            if (controller == null) continue;
+
+            controller.Init(node.GridPosition, new List<GameObject>());
+            _rooms[node.GridPosition] = controller;
+
+            if (node.RoomType == RoomType.Start)
+                ActivateRoom(controller);
+        }
+    }
+
+    public void OnPlayerEnterDoor(RoomController currentRoom, DoorFlags enteredDoor)
+    {
+        var direction = DoorFlagToVector(enteredDoor);
+        var nextPos = currentRoom.GridPosition + direction;
+
+        if (!_rooms.TryGetValue(nextPos, out var nextRoom)) return;
+
+        ActivateRoom(nextRoom);
+
+        var oppositeFlag = GetOppositeFlag(enteredDoor);
+        var spawnPoint = nextRoom.GetSpawnPoint(oppositeFlag);
+        if (spawnPoint != null)
+            GameEvents.OnRoomTransition?.Invoke(spawnPoint);
+    }
+
+    private void ActivateRoom(RoomController room)
+    {
+        _currentRoom = room;
+        room.OnRoomEnter();
+    }
+
+    public RoomController GetRoom(Vector2Int gridPosition)
+    {
+        _rooms.TryGetValue(gridPosition, out var room);
+        return room;
+    }
+
+    public static Vector2Int DoorFlagToVector(DoorFlags flag)
+    {
+        return flag switch
+        {
+            DoorFlags.North => Vector2Int.up,
+            DoorFlags.South => Vector2Int.down,
+            DoorFlags.East  => Vector2Int.right,
+            DoorFlags.West  => Vector2Int.left,
+            _               => Vector2Int.zero,
+        };
+    }
+
+    public static DoorFlags GetOppositeFlag(DoorFlags flag)
+    {
+        return flag switch
+        {
+            DoorFlags.North => DoorFlags.South,
+            DoorFlags.South => DoorFlags.North,
+            DoorFlags.East  => DoorFlags.West,
+            DoorFlags.West  => DoorFlags.East,
+            _               => DoorFlags.None,
+        };
+    }
+
+    private RoomData GetRoomData(RoomType type)
+    {
+        return _roomDataList.Find(d => d.RoomType == type);
+    }
+}


### PR DESCRIPTION
## 개요
층 전체를 관리하는 매니저 구현. MapGenerator로 방 배치를 생성하고 프리팹을 스폰해 딕셔너리로 관리함

## 관련 이슈
Closes #16

## 변경 사항
- `FloorManager.cs`
  - `MapGenerator` 호출 → 프리팹 스폰 → `RoomController` 초기화
  - 그리드 포지션 기반 딕셔너리로 방 관리
  - `OnPlayerEnterDoor()` — 다음 방 활성화 + 스폰 포인트 이벤트 발행
  - `DoorFlagToVector()`, `GetOppositeFlag()` 유틸 메서드
- `GameEvents.cs` — `OnRoomTransition`, `OnRoomClear`, `OnPlayerHit` 스텁 추가 (기존 코드에서 이미 참조 중이던 것 선언)

## 완료 기준 확인
- [x] `Assets/Scripts/Map/FloorManager.cs` 생성
- [x] 컴파일 에러 없음
- [x] 에디터에서 Play 시 맵 생성 확인

## 테스트 방법
1. 씬에 빈 오브젝트 생성 후 `FloorManager` 컴포넌트 추가
2. `RoomDataList`에 각 타입별 RoomData(프리팹 포함) 세팅
3. Play 후 방이 그리드 간격으로 스폰되는지 확인