### PR TITLE
[Feature] RoomTransitionManager 구현

### DIFF
--- a/Assets/Scripts/GameEvents.cs
+++ b/Assets/Scripts/GameEvents.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 public static class GameEvents
 {
     public static Action<Transform> OnRoomTransition;
+    public static Action OnTransitionStart;
+    public static Action OnTransitionEnd;
     public static Action OnRoomClear;
     public static Action OnPlayerHit;
 }

--- a/Assets/Scripts/Map/DoorController.cs.meta
+++ b/Assets/Scripts/Map/DoorController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3f221fbe8bbfd6b429c5d37ca524fa28

--- a/Assets/Scripts/Map/FloorManager.cs
+++ b/Assets/Scripts/Map/FloorManager.cs
@@ -9,6 +9,7 @@ public class FloorManager : MonoBehaviour
 
     private Dictionary<Vector2Int, RoomController> _rooms = new();
     private RoomController _currentRoom;
+    public RoomController CurrentRoom => _currentRoom;
 
     private void Start()
     {

--- a/Assets/Scripts/Map/MapGenerator.cs.meta
+++ b/Assets/Scripts/Map/MapGenerator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e1b4c69df7dd54047ad0117f97dfb06b

--- a/Assets/Scripts/Map/RoomController.cs.meta
+++ b/Assets/Scripts/Map/RoomController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0496cab56edab8b4095f4a051829e71c

--- a/Assets/Scripts/Map/RoomTransitionManager.cs
+++ b/Assets/Scripts/Map/RoomTransitionManager.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using UnityEngine;
+
+public class RoomTransitionManager : MonoBehaviour
+{
+    [SerializeField] private Camera _camera;
+    [SerializeField] private Transform _player;
+    [SerializeField] private float _slideDuration = 0.4f;
+
+    private bool _isTransitioning;
+
+    private void OnEnable()
+    {
+        GameEvents.OnRoomTransition += StartTransition;
+    }
+
+    private void OnDisable()
+    {
+        GameEvents.OnRoomTransition -= StartTransition;
+    }
+
+    private void StartTransition(Transform spawnPoint)
+    {
+        if (_isTransitioning) return;
+        StartCoroutine(TransitionRoutine(spawnPoint));
+    }
+
+    private IEnumerator TransitionRoutine(Transform spawnPoint)
+    {
+        _isTransitioning = true;
+
+        GameEvents.OnTransitionStart?.Invoke();
+
+        Vector3 cameraOffset = _camera.transform.position - _player.position;
+        Vector3 targetCameraPos = spawnPoint.position + cameraOffset;
+
+        Vector3 fromPos = _camera.transform.position;
+        float elapsed = 0f;
+
+        while (elapsed < _slideDuration)
+        {
+            elapsed += Time.deltaTime;
+            _camera.transform.position = Vector3.Lerp(fromPos, targetCameraPos, elapsed / _slideDuration);
+            yield return null;
+        }
+
+        _camera.transform.position = targetCameraPos;
+        _player.position = spawnPoint.position;
+
+        GameEvents.OnTransitionEnd?.Invoke();
+
+        _isTransitioning = false;
+    }
+}


### PR DESCRIPTION
## 개요
방 전환 시 카메라 슬라이드 및 플레이어 스폰 처리

## 관련 이슈
Closes #18

## 변경 사항
- `RoomTransitionManager.cs`
  - `GameEvents.OnRoomTransition` 구독
  - 코루틴으로 카메라 슬라이드 (Lerp, 기본 0.4초)
  - 전환 완료 후 플레이어를 스폰 포인트에 배치
  - `OnTransitionStart/End` 이벤트 발행 (입력 차단 등 외부에서 구독 가능)
- `GameEvents.cs` — `OnTransitionStart`, `OnTransitionEnd` 추가

## 완료 기준 확인
- [x] `Assets/Scripts/Map/RoomTransitionManager.cs` 생성
- [x] 컴파일 에러 없음
- [ ] 방 전환 시 카메라 이동 확인
- [ ] 플레이어가 올바른 스폰 포인트에 배치됨

## 테스트 방법
1. 씬에 `RoomTransitionManager` 컴포넌트 추가, Camera·Player 연결
2. 코드에서 `GameEvents.OnRoomTransition?.Invoke(spawnPoint)` 호출
3. 카메라가 슬라이드되고 플레이어가 스폰 포인트에 위치하는지 확인