### PR TITLE
[Feature] 근접 공격 몬스터 Skeleton AI 구현

### DIFF
--- a/Assets/Scenes/InGameScene_Copy.unity
+++ b/Assets/Scenes/InGameScene_Copy.unity
@@ -1741,6 +1741,67 @@ Transform:
   - {fileID: 702159776}
   m_Father: {fileID: 1694994605}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1108166643
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2004564378176708641, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_Name
+      value: Bat_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 2004564378176708641, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 9.70975
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 6.58835
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
 --- !u!1001 &1116395748
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -2918,6 +2979,18 @@ PrefabInstance:
     m_TransformParent: {fileID: 0}
     m_Modifications:
     - target: {fileID: 4593010734294121198, guid: fd0a980aea17daa4d99898749659b908, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4593010734294121198, guid: fd0a980aea17daa4d99898749659b908, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4593010734294121198, guid: fd0a980aea17daa4d99898749659b908, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 1.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 4593010734294121198, guid: fd0a980aea17daa4d99898749659b908, type: 3}
       propertyPath: m_LocalPosition.x
       value: 5.00751
       objectReference: {fileID: 0}
@@ -2960,6 +3033,10 @@ PrefabInstance:
     - target: {fileID: 7455902964127376280, guid: fd0a980aea17daa4d99898749659b908, type: 3}
       propertyPath: m_Name
       value: Flower_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 7455902964127376280, guid: fd0a980aea17daa4d99898749659b908, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -3155,6 +3232,63 @@ Transform:
   m_Children: []
   m_Father: {fileID: 1088071085}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1581058677
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4004630476116519662, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_Name
+      value: Skeleton_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 3.9904
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -2.34059
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: -0.3019034
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0.95333856
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 215.144
+      objectReference: {fileID: 0}
+    - target: {fileID: 5092479782054067774, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: e8d58ecb3cd19b4439e19feb320502ca, type: 3}
 --- !u!1 &1585103957
 GameObject:
   m_ObjectHideFlags: 0
@@ -3495,6 +3629,10 @@ PrefabInstance:
     - target: {fileID: 2023812424098319386, guid: 1d11597fe30d6794383b5d57ff5306b8, type: 3}
       propertyPath: m_Name
       value: Boss_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 2023812424098319386, guid: 1d11597fe30d6794383b5d57ff5306b8, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4526,3 +4664,5 @@ SceneRoots:
   - {fileID: 1696962430}
   - {fileID: 1687009251}
   - {fileID: 1531528715}
+  - {fileID: 1108166643}
+  - {fileID: 1581058677}

--- a/Assets/Scripts/Enemy/Skeleton.meta
+++ b/Assets/Scripts/Enemy/Skeleton.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd131739790c04a4ebecb2d49ab06898
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Enemy/Skeleton/SkeletonAttack.cs
+++ b/Assets/Scripts/Enemy/Skeleton/SkeletonAttack.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+public class SkeletonAttack : EnemyAttackBase
+{
+    [SerializeField] private int damage = 1;
+    [SerializeField] private float _attackRadius = 1.2f;
+    [SerializeField] private float _attackOffset = 0.8f;
+    [SerializeField] private LayerMask _playerLayerMask;
+
+    public override void Execute(Transform self, Transform target)
+    {
+        Vector3 attackCenter = self.position + self.forward * _attackOffset;
+        Collider[] hits = Physics.OverlapSphere(attackCenter, _attackRadius, _playerLayerMask);
+
+        foreach (var hit in hits)
+        {
+            if (hit.TryGetComponent<IDamageable>(out var damageable))
+                damageable.TakeDamage(damage);
+        }
+    }
+}

--- a/Assets/Scripts/Enemy/Skeleton/SkeletonAttack.cs.meta
+++ b/Assets/Scripts/Enemy/Skeleton/SkeletonAttack.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 826a7fe769387894e98659c38e2c5528

--- a/Assets/Scripts/Enemy/Skeleton/SkeletonEnemy.cs
+++ b/Assets/Scripts/Enemy/Skeleton/SkeletonEnemy.cs
@@ -1,0 +1,191 @@
+using UnityEngine;
+
+// 근접 공격형 몬스터. 칼 휘두르기는 Physics.OverlapSphere로 전방 범위 판정.
+//
+// BT 우선순위:
+//   1. 사망     : 체력 <= 0 → Die()
+//   2. 피격경직 : 피격 직후 경직
+//   3. 공격     : 공격 범위 내 + 쿨다운 완료 → 정지 후 OverlapSphere 판정
+//   4. 추적     : 탐지 범위 내 → 플레이어 방향으로 이동 + 시선 추적
+//   5. 순찰     : 랜덤 방향으로 이동
+public class SkeletonEnemy : EnemyBase
+{
+    [Header("Rotation")]
+    [SerializeField] private float _rotationSpeed = 10f;
+
+    [Header("Wall Avoidance")]
+    [SerializeField] private LayerMask _wallLayerMask;
+    [SerializeField] private float _wallCheckDistance = 1.5f;
+
+    private Vector3 _patrolDir;
+    private float _patrolDirTimer;
+
+    private Animator _animator;
+    private static readonly int AttackHash     = Animator.StringToHash("Attack");
+    private static readonly int TakeDamageHash = Animator.StringToHash("TakeDamage");
+    private static readonly int DieHash        = Animator.StringToHash("Die");
+    private static readonly int IsWalkingHash  = Animator.StringToHash("IsWalking");
+    private static readonly int IsRunningHash  = Animator.StringToHash("IsRunning");
+
+    private bool isAttacking;
+    private float attackTimer;
+    private float hitStunTimer;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        _animator = GetComponentInChildren<Animator>();
+    }
+
+    protected override BehaviorNode BuildTree()
+    {
+        return new SelectorNode()
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(() => IsDead))
+                .AddChild(new ActionNode(DeadAction)))
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(() => isHit))
+                .AddChild(new ActionNode(HitStunAction)))
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(ShouldAttack))
+                .AddChild(new ActionNode(AttackAction)))
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(InSearchRange))
+                .AddChild(new ActionNode(() => { Attacker?.TickCooldown(); ChaseAndFace(); SetRunning(); return NodeState.Running; })))
+            .AddChild(new ActionNode(() => { WallAwarePatrol(); SetWalking(); return NodeState.Running; }));
+    }
+
+    private bool InSearchRange()
+    {
+        if (PlayerTransform == null) return false;
+        return Vector3.Distance(transform.position, PlayerTransform.position) <= SearchRange;
+    }
+
+    private bool ShouldAttack()
+    {
+        if (isAttacking) return true;
+        if (Attacker == null || PlayerTransform == null || !Attacker.IsReady) return false;
+        return Vector3.Distance(transform.position, PlayerTransform.position) <= Attacker.AttackRange;
+    }
+
+    private void WallAwarePatrol()
+    {
+        _patrolDirTimer -= Time.deltaTime;
+
+        bool wallAhead = _patrolDir != Vector3.zero
+                      && Physics.Raycast(transform.position, _patrolDir, _wallCheckDistance, _wallLayerMask);
+
+        if (_patrolDirTimer <= 0f || wallAhead)
+        {
+            _patrolDir = PickSafePatrolDirection();
+            _patrolDirTimer = patrolDirectionInterval;
+        }
+
+        Rb.linearVelocity = _patrolDir * MoveSpeed * patrolSpeedMultiplier;
+        FaceDirection(_patrolDir);
+    }
+
+    // 수평 ray만 사용하므로 바닥(수평면)은 감지 안 됨 (Environment 레이어 바닥+벽 공유 대응)
+    private Vector3 PickSafePatrolDirection()
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            float angle = Random.Range(0f, 360f) * Mathf.Deg2Rad;
+            Vector3 candidate = new Vector3(Mathf.Cos(angle), 0f, Mathf.Sin(angle));
+            if (!Physics.Raycast(transform.position, candidate, _wallCheckDistance, _wallLayerMask))
+                return candidate;
+        }
+        return -_patrolDir;
+    }
+
+    public override void Chase()
+    {
+        if (PlayerTransform == null) return;
+
+        Vector3 dir = (PlayerTransform.position - transform.position);
+        dir.y = 0f;
+        dir.Normalize();
+
+        // 플레이어 방향에 벽이 있으면 벽면을 따라 슬라이딩
+        if (Physics.Raycast(transform.position, dir, _wallCheckDistance, _wallLayerMask))
+        {
+            Vector3 right = Vector3.Cross(Vector3.up, dir);
+            if (!Physics.Raycast(transform.position, right, _wallCheckDistance, _wallLayerMask))
+                dir = right;
+            else if (!Physics.Raycast(transform.position, -right, _wallCheckDistance, _wallLayerMask))
+                dir = -right;
+            else
+                dir = Vector3.zero;
+        }
+
+        Rb.linearVelocity = dir * MoveSpeed;
+    }
+
+    private void ChaseAndFace()
+    {
+        Chase();
+        if (PlayerTransform != null)
+        {
+            Vector3 dir = PlayerTransform.position - transform.position;
+            dir.y = 0f;
+            FaceDirection(dir.normalized);
+        }
+    }
+
+    private void SetWalking()  { _animator?.SetBool(IsWalkingHash, true);  _animator?.SetBool(IsRunningHash, false); }
+    private void SetRunning()  { _animator?.SetBool(IsWalkingHash, false); _animator?.SetBool(IsRunningHash, true);  }
+    private void SetStopped()  { _animator?.SetBool(IsWalkingHash, false); _animator?.SetBool(IsRunningHash, false); }
+
+    private void FaceDirection(Vector3 dir)
+    {
+        if (dir.sqrMagnitude < 0.01f) return;
+        transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(dir), Time.deltaTime * _rotationSpeed);
+    }
+
+    private NodeState DeadAction()
+    {
+        _animator?.SetTrigger(DieHash);
+        Die();
+        return NodeState.Running;
+    }
+
+    private NodeState HitStunAction()
+    {
+        if (hitStunTimer <= 0f)
+        {
+            hitStunTimer = HitStunDuration;
+            SetStopped();
+            _animator?.SetTrigger(TakeDamageHash);
+            Hit();
+        }
+
+        hitStunTimer -= Time.deltaTime;
+        if (hitStunTimer > 0f) return NodeState.Running;
+
+        isHit = false;
+        hitStunTimer = 0f;
+        return NodeState.Success;
+    }
+
+    // 공격 시 정지 후 OverlapSphere 판정 → attackDuration 동안 Running 유지
+    private NodeState AttackAction()
+    {
+        if (!isAttacking)
+        {
+            isAttacking = true;
+            attackTimer = Attacker.AttackDuration;
+            Rb.linearVelocity = Vector3.zero;
+            SetStopped();
+            _animator?.SetTrigger(AttackHash);
+            Attack();
+        }
+
+        Rb.linearVelocity = Vector3.zero;
+        attackTimer -= Time.deltaTime;
+        if (attackTimer > 0f) return NodeState.Running;
+
+        isAttacking = false;
+        Attacker.StartCooldown();
+        return NodeState.Success;
+    }
+}

--- a/Assets/Scripts/Enemy/Skeleton/SkeletonEnemy.cs.meta
+++ b/Assets/Scripts/Enemy/Skeleton/SkeletonEnemy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 50867321a62185648961dbafe753e8a3


### PR DESCRIPTION
## 개요
칼을 휘두르는 근접 공격형 몬스터 Skeleton을 구현했음

## 변경 사항
- **SkeletonEnemy**: Patrol → Chase → Attack BT 구성, 플레이어 방향 시선 추적
- **WallAwarePatrol**: 수평 Raycast로 전방 벽 감지 시 안전한 방향 재선택 (isTrigger 맵 이탈 방지)
- **Chase 오버라이드**: 플레이어 방향에 벽이 있으면 벽면을 따라 좌/우 슬라이딩
- **SkeletonAttack**: Physics.OverlapSphere로 전방 근접 범위 판정 후 피해 적용
- Animator 연동: `IsWalking` / `IsRunning` (Bool), `Attack` / `TakeDamage` / `Die` (Trigger)

Closes #62