### PR TITLE
Feature/#70 bee king enemy

### DIFF
--- a/Assets/Scenes/InGameScene_Copy.unity
+++ b/Assets/Scenes/InGameScene_Copy.unity
@@ -282,6 +282,75 @@ Transform:
   - {fileID: 1116395749}
   m_Father: {fileID: 497876349}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &106448663
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.84179
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.54178
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      propertyPath: m_Name
+      value: Bee_Enemy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1615335402}
+    - targetCorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1615335401}
+    - targetCorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1615335400}
+    - targetCorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 1615335399}
+  m_SourcePrefab: {fileID: 100100000, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
 --- !u!1 &158133565
 GameObject:
   m_ObjectHideFlags: 0
@@ -1741,6 +1810,10 @@ PrefabInstance:
     - target: {fileID: 2004564378176708641, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
       propertyPath: m_Name
       value: Bat_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 2004564378176708641, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3422,6 +3495,94 @@ Transform:
   m_Children: []
   m_Father: {fileID: 474803382}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1615335398 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
+  m_PrefabInstance: {fileID: 106448663}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &1615335399
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615335398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9448f280cd73b52459520e289e060834, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::DamageOnContact
+  _damage: 1
+  _damageCooldown: 2
+--- !u!114 &1615335400
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615335398}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3857b4623f280e84eafd9d1b707fa0da, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::BeeEnemy
+  maxHp: 3
+  moveSpeed: 3
+  hitStunDuration: 0.2
+  knockbackForce: 5
+  searchRange: 10
+  patrolDirectionInterval: 2
+  patrolSpeedMultiplier: 0.5
+--- !u!54 &1615335401
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615335398}
+  serializedVersion: 5
+  m_Mass: 1
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 84
+  m_CollisionDetection: 0
+--- !u!136 &1615335402
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1615335398}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 1
+  m_Direction: 1
+  m_Center: {x: 0, y: 0.8, z: 0}
 --- !u!1 &1633555827
 GameObject:
   m_ObjectHideFlags: 0
@@ -3600,6 +3761,10 @@ PrefabInstance:
     - target: {fileID: 2023812424098319386, guid: 1d11597fe30d6794383b5d57ff5306b8, type: 3}
       propertyPath: m_Name
       value: Boss_Enemy
+      objectReference: {fileID: 0}
+    - target: {fileID: 2023812424098319386, guid: 1d11597fe30d6794383b5d57ff5306b8, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4634,3 +4799,4 @@ SceneRoots:
   - {fileID: 1531528715}
   - {fileID: 1108166643}
   - {fileID: 1581058677}
+  - {fileID: 106448663}

--- a/Assets/Scenes/InGameScene_Copy.unity
+++ b/Assets/Scenes/InGameScene_Copy.unity
@@ -292,7 +292,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 7.84179
+      value: 17.25
       objectReference: {fileID: 0}
     - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
       propertyPath: m_LocalPosition.y
@@ -300,7 +300,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
       propertyPath: m_LocalPosition.z
-      value: -4.54178
+      value: -9.46
       objectReference: {fileID: 0}
     - target: {fileID: 2012373132104083579, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
       propertyPath: m_LocalRotation.w
@@ -337,19 +337,7 @@ PrefabInstance:
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents:
-    - targetCorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1615335402}
-    - targetCorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1615335401}
-    - targetCorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1615335400}
-    - targetCorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
-      insertIndex: -1
-      addedObject: {fileID: 1615335399}
+    m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
 --- !u!1 &158133565
 GameObject:
@@ -1810,10 +1798,6 @@ PrefabInstance:
     - target: {fileID: 2004564378176708641, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
       propertyPath: m_Name
       value: Bat_Enemy
-      objectReference: {fileID: 0}
-    - target: {fileID: 2004564378176708641, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4263854746409993396, guid: 45e9ca0f050cb1c43b7bf0ed6ce09323, type: 3}
       propertyPath: m_LocalPosition.x
@@ -3495,94 +3479,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 474803382}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1615335398 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 5131146826095487095, guid: 702a7a870b8104242a682a18852a31ae, type: 3}
-  m_PrefabInstance: {fileID: 106448663}
-  m_PrefabAsset: {fileID: 0}
---- !u!114 &1615335399
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615335398}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9448f280cd73b52459520e289e060834, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::DamageOnContact
-  _damage: 1
-  _damageCooldown: 2
---- !u!114 &1615335400
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615335398}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 3857b4623f280e84eafd9d1b707fa0da, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::BeeEnemy
-  maxHp: 3
-  moveSpeed: 3
-  hitStunDuration: 0.2
-  knockbackForce: 5
-  searchRange: 10
-  patrolDirectionInterval: 2
-  patrolSpeedMultiplier: 0.5
---- !u!54 &1615335401
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615335398}
-  serializedVersion: 5
-  m_Mass: 1
-  m_LinearDamping: 0
-  m_AngularDamping: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 0
-  m_IsKinematic: 0
-  m_Interpolate: 0
-  m_Constraints: 84
-  m_CollisionDetection: 0
---- !u!136 &1615335402
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1615335398}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 1
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 1
-  m_Direction: 1
-  m_Center: {x: 0, y: 0.8, z: 0}
 --- !u!1 &1633555827
 GameObject:
   m_ObjectHideFlags: 0
@@ -3761,10 +3657,6 @@ PrefabInstance:
     - target: {fileID: 2023812424098319386, guid: 1d11597fe30d6794383b5d57ff5306b8, type: 3}
       propertyPath: m_Name
       value: Boss_Enemy
-      objectReference: {fileID: 0}
-    - target: {fileID: 2023812424098319386, guid: 1d11597fe30d6794383b5d57ff5306b8, type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -4785,6 +4677,63 @@ Transform:
   - {fileID: 659662340}
   m_Father: {fileID: 191527895}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &5500489702593527357
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.65064
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -4.09722
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7523112445824682958, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9093301963227017638, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
+      propertyPath: m_Name
+      value: BeeKing_Enemy
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 5cf672e96be026741957131e74ae97d3, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -4800,3 +4749,4 @@ SceneRoots:
   - {fileID: 1108166643}
   - {fileID: 1581058677}
   - {fileID: 106448663}
+  - {fileID: 5500489702593527357}

--- a/Assets/Scripts/Enemy/BeeEnemy.cs
+++ b/Assets/Scripts/Enemy/BeeEnemy.cs
@@ -3,7 +3,9 @@ using UnityEngine;
 // Bee 비행 몬스터 BT 우선순위:
 //   1. 사망     : 체력 <= 0 → Die()
 //   2. 피격경직 : 피격 직후 경직
-//   3. 추적     : 한 번 탐색 범위 진입 후 영구 추적 (XZ 평면, 벽 슬라이딩)
+//   3. 추적/공전: 한 번 탐색 범위 진입 후 영구 활성
+//      - 공전 모드(_orbitCenter != null): Bee King 주위를 일정 반경으로 공전
+//      - 추적 모드: 지정된 타겟(기본 플레이어) XZ 추적 (벽 슬라이딩)
 //   4. 순찰     : 랜덤 이동 (벽 감지 시 방향 재선택)
 //
 // 데미지는 BT가 아닌 DamageOnContact 컴포넌트가 OnTriggerStay로 자동 처리한다.
@@ -27,6 +29,33 @@ public class BeeEnemy : EnemyBase
     private bool _isAggro;
     private bool _dieAnimTriggered;
 
+    // 추적 모드
+    private Transform _chaseTarget;
+    private Transform ChaseTarget => _chaseTarget != null ? _chaseTarget : PlayerTransform;
+
+    // 공전 모드 (Bee King 주위)
+    private Transform _orbitCenter;
+    private float _orbitRadius;
+    private float _orbitAngle;
+
+    // BeeKingEnemy 소환 직후: 일정 반경 공전
+    public void ForceOrbit(Transform center, float radius)
+    {
+        _isAggro = true;
+        _orbitCenter = center;
+        _orbitRadius = radius;
+        _orbitAngle = Random.Range(0f, 360f);
+        _chaseTarget = null;
+    }
+
+    // BeeKingEnemy 릴리즈 시: 지정 타겟(플레이어) 직접 추적
+    public void ForceChase(Transform target)
+    {
+        _isAggro = true;
+        _orbitCenter = null;
+        _chaseTarget = target;
+    }
+
     protected override void Awake()
     {
         base.Awake();
@@ -43,9 +72,20 @@ public class BeeEnemy : EnemyBase
     private void UpdateFacing()
     {
         if (IsDead) return;
-        Vector3 targetDir = (_isAggro && PlayerTransform != null)
-            ? (PlayerTransform.position - transform.position)
-            : _patrolDir;
+        Vector3 targetDir;
+        if (_isAggro)
+        {
+            if (_orbitCenter != null)
+                targetDir = _orbitCenter.position - transform.position;
+            else if (ChaseTarget != null)
+                targetDir = ChaseTarget.position - transform.position;
+            else
+                targetDir = _patrolDir;
+        }
+        else
+        {
+            targetDir = _patrolDir;
+        }
         targetDir.y = 0f;
         if (targetDir.sqrMagnitude < 0.01f) return;
         transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(targetDir), Time.deltaTime * _rotationSpeed);
@@ -68,8 +108,17 @@ public class BeeEnemy : EnemyBase
 
     private void ChaseXZ()
     {
-        if (PlayerTransform == null) return;
-        Vector3 dir = PlayerTransform.position - transform.position;
+        // 공전 중이라도 플레이어가 절반 탐지 범위 안에 들어오면 직접 추적으로 전환
+        if (_orbitCenter != null && PlayerTransform != null &&
+            Vector3.Distance(transform.position, PlayerTransform.position) <= SearchRange * 0.5f)
+        {
+            ForceChase(PlayerTransform);
+        }
+
+        if (_orbitCenter != null) { OrbitAround(); return; }
+
+        if (ChaseTarget == null) return;
+        Vector3 dir = ChaseTarget.position - transform.position;
         dir.y = 0f;
         dir.Normalize();
 
@@ -85,6 +134,35 @@ public class BeeEnemy : EnemyBase
         }
 
         Rb.linearVelocity = dir * MoveSpeed;
+    }
+
+    private void OrbitAround()
+    {
+        // Bee King이 사망하면 플레이어 추적으로 전환
+        if (_orbitCenter == null) { _chaseTarget = null; return; }
+
+        _orbitAngle += MoveSpeed / _orbitRadius * Mathf.Rad2Deg * Time.deltaTime;
+
+        float rad = _orbitAngle * Mathf.Deg2Rad;
+        Vector3 targetPos = _orbitCenter.position + new Vector3(Mathf.Cos(rad), 0f, Mathf.Sin(rad)) * _orbitRadius;
+
+        Vector3 dir = targetPos - transform.position;
+        dir.y = 0f;
+
+        if (dir.magnitude < 0.15f)
+        {
+            Rb.linearVelocity = Vector3.zero;
+            return;
+        }
+
+        Vector3 moveDir = dir.normalized;
+        if (Physics.Raycast(transform.position, moveDir, _wallCheckDistance, _wallLayerMask))
+        {
+            Rb.linearVelocity = Vector3.zero;
+            return;
+        }
+
+        Rb.linearVelocity = moveDir * MoveSpeed;
     }
 
     private void WallAwarePatrol()
@@ -117,8 +195,8 @@ public class BeeEnemy : EnemyBase
 
     private bool ShouldChase()
     {
-        if (PlayerTransform == null) return false;
-        if (!_isAggro && Vector3.Distance(transform.position, PlayerTransform.position) <= SearchRange)
+        if (!_isAggro && PlayerTransform != null &&
+            Vector3.Distance(transform.position, PlayerTransform.position) <= SearchRange)
             _isAggro = true;
         return _isAggro;
     }

--- a/Assets/Scripts/Enemy/BeeEnemy.cs
+++ b/Assets/Scripts/Enemy/BeeEnemy.cs
@@ -1,0 +1,151 @@
+using UnityEngine;
+
+// Bee 비행 몬스터 BT 우선순위:
+//   1. 사망     : 체력 <= 0 → Die()
+//   2. 피격경직 : 피격 직후 경직
+//   3. 추적     : 한 번 탐색 범위 진입 후 영구 추적 (XZ 평면, 벽 슬라이딩)
+//   4. 순찰     : 랜덤 이동 (벽 감지 시 방향 재선택)
+//
+// 데미지는 BT가 아닌 DamageOnContact 컴포넌트가 OnTriggerStay로 자동 처리한다.
+// Y축 고정으로 소환 위치의 비행 높이를 유지한다.
+public class BeeEnemy : EnemyBase
+{
+    [Header("Wall Avoidance")]
+    [SerializeField] private LayerMask _wallLayerMask;
+    [SerializeField] private float _wallCheckDistance = 2f;
+
+    [Header("Rotation")]
+    [SerializeField] private float _rotationSpeed = 10f;
+
+    private Animator _animator;
+    private static readonly int HitId = Animator.StringToHash("hit");
+    private static readonly int DieId = Animator.StringToHash("die");
+
+    private Vector3 _patrolDir;
+    private float _patrolDirTimer;
+    private float hitStunTimer;
+    private bool _isAggro;
+    private bool _dieAnimTriggered;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        _animator = GetComponent<Animator>();
+        Rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotation;
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+        UpdateFacing();
+    }
+
+    private void UpdateFacing()
+    {
+        if (IsDead) return;
+        Vector3 targetDir = (_isAggro && PlayerTransform != null)
+            ? (PlayerTransform.position - transform.position)
+            : _patrolDir;
+        targetDir.y = 0f;
+        if (targetDir.sqrMagnitude < 0.01f) return;
+        transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(targetDir), Time.deltaTime * _rotationSpeed);
+    }
+
+    protected override BehaviorNode BuildTree()
+    {
+        return new SelectorNode()
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(() => IsDead))
+                .AddChild(new ActionNode(DeadAction)))
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(() => isHit))
+                .AddChild(new ActionNode(HitStunAction)))
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(ShouldChase))
+                .AddChild(new ActionNode(() => { ChaseXZ(); return NodeState.Running; })))
+            .AddChild(new ActionNode(() => { WallAwarePatrol(); return NodeState.Running; }));
+    }
+
+    private void ChaseXZ()
+    {
+        if (PlayerTransform == null) return;
+        Vector3 dir = PlayerTransform.position - transform.position;
+        dir.y = 0f;
+        dir.Normalize();
+
+        if (Physics.Raycast(transform.position, dir, _wallCheckDistance, _wallLayerMask))
+        {
+            Vector3 right = Vector3.Cross(Vector3.up, dir);
+            if (!Physics.Raycast(transform.position, right, _wallCheckDistance, _wallLayerMask))
+                dir = right;
+            else if (!Physics.Raycast(transform.position, -right, _wallCheckDistance, _wallLayerMask))
+                dir = -right;
+            else
+                dir = Vector3.zero;
+        }
+
+        Rb.linearVelocity = dir * MoveSpeed;
+    }
+
+    private void WallAwarePatrol()
+    {
+        _patrolDirTimer -= Time.deltaTime;
+
+        bool wallAhead = _patrolDir != Vector3.zero
+                      && Physics.Raycast(transform.position, _patrolDir, _wallCheckDistance, _wallLayerMask);
+
+        if (_patrolDirTimer <= 0f || wallAhead)
+        {
+            _patrolDir = PickSafePatrolDirection();
+            _patrolDirTimer = patrolDirectionInterval;
+        }
+
+        Rb.linearVelocity = _patrolDir * MoveSpeed * patrolSpeedMultiplier;
+    }
+
+    private Vector3 PickSafePatrolDirection()
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            float angle = Random.Range(0f, 360f) * Mathf.Deg2Rad;
+            Vector3 candidate = new Vector3(Mathf.Cos(angle), 0f, Mathf.Sin(angle));
+            if (!Physics.Raycast(transform.position, candidate, _wallCheckDistance, _wallLayerMask))
+                return candidate;
+        }
+        return -_patrolDir;
+    }
+
+    private bool ShouldChase()
+    {
+        if (PlayerTransform == null) return false;
+        if (!_isAggro && Vector3.Distance(transform.position, PlayerTransform.position) <= SearchRange)
+            _isAggro = true;
+        return _isAggro;
+    }
+
+    private NodeState DeadAction()
+    {
+        if (!_dieAnimTriggered)
+        {
+            _dieAnimTriggered = true;
+            if (_animator != null) _animator.SetTrigger(DieId);
+        }
+        Die();
+        return NodeState.Running;
+    }
+
+    private NodeState HitStunAction()
+    {
+        if (hitStunTimer <= 0f)
+        {
+            hitStunTimer = HitStunDuration;
+            if (_animator != null) _animator.SetTrigger(HitId);
+            Hit();
+        }
+        hitStunTimer -= Time.deltaTime;
+        if (hitStunTimer > 0f) return NodeState.Running;
+        isHit = false;
+        hitStunTimer = 0f;
+        return NodeState.Success;
+    }
+}

--- a/Assets/Scripts/Enemy/BeeEnemy.cs.meta
+++ b/Assets/Scripts/Enemy/BeeEnemy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3857b4623f280e84eafd9d1b707fa0da

--- a/Assets/Scripts/Enemy/BeeKingEnemy.cs
+++ b/Assets/Scripts/Enemy/BeeKingEnemy.cs
@@ -1,0 +1,222 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+// Bee King 보스 BT 우선순위:
+//   1. 사망      : 체력 <= 0 → Die()
+//   2. 피격경직  : 피격 직후 경직
+//   3. 패턴 실행 : 범위 내 + 쿨다운 완료 → 가중치 랜덤 패턴 선택
+//      - 패턴 0  : Bee 다수 소환 → 소환된 Bee들은 Bee King 주위를 공전 (75% 확률)
+//      - 패턴 1  : 공전 중인 Bee 전부 플레이어 방향으로 전환 (25% 확률, 최소 4마리 이상일 때만)
+//   4. 부유      : 느리게 랜덤 방향으로 이동 (벽 회피)
+public class BeeKingEnemy : EnemyBase
+{
+    [Header("Pattern Settings")]
+    [SerializeField] private float patternCooldown = 3f;
+    [SerializeField] private float attackRange = 14f;
+
+    [Header("Summon")]
+    [SerializeField] private GameObject _beePrefab;
+    [SerializeField] private int _summonCount = 4;
+    [SerializeField] private float _summonRadius = 2.5f;
+
+    [Header("Wall Avoidance")]
+    [SerializeField] private LayerMask _wallLayerMask;
+    [SerializeField] private float _wallCheckDistance = 2f;
+
+    [Header("Rotation")]
+    [SerializeField] private float _rotationSpeed = 8f;
+
+    private Animator _animator;
+    private static readonly int HitId    = Animator.StringToHash("hit");
+    private static readonly int DieId    = Animator.StringToHash("die");
+    private static readonly int AttackId = Animator.StringToHash("attack");
+
+    private readonly List<BeeEnemy> _summonedBees = new();
+    private float patternCooldownTimer;
+    private float hitStunTimer;
+    private bool isExecutingPattern;
+    private int currentPattern;
+    private bool _dieAnimTriggered;
+
+    private Vector3 _floatDir;
+    private float _floatDirTimer;
+
+    protected override void Awake()
+    {
+        base.Awake();
+        _animator = GetComponent<Animator>();
+        Rb.constraints = RigidbodyConstraints.FreezePositionY | RigidbodyConstraints.FreezeRotation;
+    }
+
+    protected override void Update()
+    {
+        base.Update();
+        FacePlayer();
+    }
+
+    private void FacePlayer()
+    {
+        if (PlayerTransform == null || IsDead) return;
+        Vector3 dir = PlayerTransform.position - transform.position;
+        dir.y = 0f;
+        if (dir.sqrMagnitude < 0.01f) return;
+        transform.rotation = Quaternion.Slerp(transform.rotation, Quaternion.LookRotation(dir), Time.deltaTime * _rotationSpeed);
+    }
+
+    protected override BehaviorNode BuildTree()
+    {
+        return new SelectorNode()
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(() => IsDead))
+                .AddChild(new ActionNode(DeadAction)))
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(() => isHit))
+                .AddChild(new ActionNode(HitStunAction)))
+            .AddChild(new SequenceNode()
+                .AddChild(new ConditionNode(ShouldExecutePattern))
+                .AddChild(new ActionNode(PatternAction)))
+            .AddChild(new ActionNode(FloatAction));
+    }
+
+    private bool ShouldExecutePattern()
+    {
+        if (isExecutingPattern) return true;
+        if (patternCooldownTimer > 0f || PlayerTransform == null) return false;
+        return Vector3.Distance(transform.position, PlayerTransform.position) <= attackRange;
+    }
+
+    private NodeState PatternAction()
+    {
+        if (!isExecutingPattern)
+        {
+            isExecutingPattern = true;
+            CleanDeadBees();
+
+            // 살아있는 bee가 3마리 이하면 무조건 소환 패턴
+            // 그 이상이면 75% 소환 / 25% 릴리즈
+            if (_summonedBees.Count <= 2)
+                currentPattern = 0;
+            else
+                currentPattern = (Random.Range(0, 3) == 0) ? 1 : 0;
+        }
+
+        return currentPattern switch
+        {
+            0 => SummonBeesPattern(),
+            1 => ReleaseBeesPattern(),
+            _ => FinishPattern()
+        };
+    }
+
+    // 패턴 0: Bee King 주위에 Bee 소환 → 공전 시작
+    private NodeState SummonBeesPattern()
+    {
+        if (_beePrefab == null) return FinishPattern();
+
+        for (int i = 0; i < _summonCount; i++)
+        {
+            float angle = (360f / _summonCount) * i * Mathf.Deg2Rad;
+            Vector3 offset = new Vector3(Mathf.Cos(angle), 0f, Mathf.Sin(angle)) * _summonRadius;
+            Vector3 spawnPos = transform.position + offset;
+
+            GameObject go = Instantiate(_beePrefab, spawnPos, Quaternion.identity);
+            if (go.TryGetComponent<BeeEnemy>(out var bee))
+            {
+                bee.ForceOrbit(transform, _summonRadius);
+                _summonedBees.Add(bee);
+            }
+        }
+
+        return FinishPattern();
+    }
+
+    // 패턴 1: 공전 중인 Bee 전부 플레이어로 전환
+    private NodeState ReleaseBeesPattern()
+    {
+        if (PlayerTransform == null) return FinishPattern();
+
+        if (_animator != null) _animator.SetTrigger(AttackId);
+
+        foreach (var bee in _summonedBees)
+        {
+            if (bee != null) bee.ForceChase(PlayerTransform);
+        }
+        _summonedBees.Clear();
+
+        return FinishPattern();
+    }
+
+    // 느린 랜덤 부유 (벽 회피)
+    private NodeState FloatAction()
+    {
+        patternCooldownTimer = Mathf.Max(0f, patternCooldownTimer - Time.deltaTime);
+
+        _floatDirTimer -= Time.deltaTime;
+        bool wallAhead = _floatDir != Vector3.zero
+                      && Physics.Raycast(transform.position, _floatDir, _wallCheckDistance, _wallLayerMask);
+
+        if (_floatDirTimer <= 0f || wallAhead)
+        {
+            _floatDir = PickSafeDirection();
+            _floatDirTimer = patrolDirectionInterval;
+        }
+
+        Rb.linearVelocity = _floatDir * MoveSpeed * patrolSpeedMultiplier;
+        return NodeState.Running;
+    }
+
+    private Vector3 PickSafeDirection()
+    {
+        for (int i = 0; i < 8; i++)
+        {
+            float angle = Random.Range(0f, 360f) * Mathf.Deg2Rad;
+            Vector3 candidate = new Vector3(Mathf.Cos(angle), 0f, Mathf.Sin(angle));
+            if (!Physics.Raycast(transform.position, candidate, _wallCheckDistance, _wallLayerMask))
+                return candidate;
+        }
+        return -_floatDir;
+    }
+
+    private void CleanDeadBees()
+    {
+        _summonedBees.RemoveAll(b => b == null);
+    }
+
+    private NodeState FinishPattern()
+    {
+        isExecutingPattern = false;
+        patternCooldownTimer = patternCooldown;
+        return NodeState.Success;
+    }
+
+    public override void Hit()
+    {
+        Rb.linearVelocity = Vector3.zero;
+    }
+
+    private NodeState DeadAction()
+    {
+        if (!_dieAnimTriggered)
+        {
+            _dieAnimTriggered = true;
+            if (_animator != null) _animator.SetTrigger(DieId);
+        }
+        Die();
+        return NodeState.Running;
+    }
+
+    private NodeState HitStunAction()
+    {
+        if (hitStunTimer <= 0f)
+        {
+            hitStunTimer = HitStunDuration;
+            if (_animator != null) _animator.SetTrigger(HitId);
+            Hit();
+        }
+        hitStunTimer -= Time.deltaTime;
+        if (hitStunTimer > 0f) return NodeState.Running;
+        isHit = false;
+        hitStunTimer = 0f;
+        return NodeState.Success;
+    }
+}

--- a/Assets/Scripts/Enemy/BeeKingEnemy.cs.meta
+++ b/Assets/Scripts/Enemy/BeeKingEnemy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 44cf3d67efd581d4ba967a4fea95efc6

--- a/Assets/Scripts/Enemy/Boss/Monstro/MonstroEnemy.cs
+++ b/Assets/Scripts/Enemy/Boss/Monstro/MonstroEnemy.cs
@@ -299,6 +299,11 @@ public class MonstroEnemy : EnemyBase
         _animator.speed = jumping ? jumpAnimSpeed : 1f;
     }
 
+    public override void Hit()
+    {
+        Rb.linearVelocity = Vector3.zero;
+    }
+
     private NodeState DeadAction()
     {
         if (!_dieAnimTriggered)

--- a/Assets/Settings/DefaultVolumeProfile.asset
+++ b/Assets/Settings/DefaultVolumeProfile.asset
@@ -342,6 +342,9 @@ MonoBehaviour:
   skyOcclusionIntensityMultiplier:
     m_OverrideState: 1
     m_Value: 1
+  worldOffset:
+    m_OverrideState: 1
+    m_Value: {x: 0, y: 0, z: 0}
 --- !u!114 &-1216621516061285780
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -374,6 +377,9 @@ MonoBehaviour:
     m_OverrideState: 1
     m_Value: {r: 1, g: 1, b: 1, a: 1}
   highQualityFiltering:
+    m_OverrideState: 1
+    m_Value: 0
+  filter:
     m_OverrideState: 1
     m_Value: 0
   downscale:
@@ -462,8 +468,6 @@ MonoBehaviour:
   - {fileID: -6288072647309666549}
   - {fileID: 7518938298396184218}
   - {fileID: -1410297666881709256}
-  - {fileID: -7750755424749557576}
-  - {fileID: -5139089513906902183}
 --- !u!114 &853819529557874667
 MonoBehaviour:
   m_ObjectHideFlags: 3

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -6,7 +6,7 @@ QualitySettings:
   serializedVersion: 5
   m_CurrentQuality: 1
   m_QualitySettings:
-  - serializedVersion: 4
+  - serializedVersion: 5
     name: Mobile
     pixelLightCount: 2
     shadows: 2
@@ -34,6 +34,7 @@ QualitySettings:
     adaptiveVsyncExtraA: 0
     adaptiveVsyncExtraB: 0
     lodBias: 1
+    meshLodThreshold: 1
     maximumLODLevel: 0
     enableLODCrossFade: 1
     streamingMipmapsActive: 0
@@ -47,8 +48,7 @@ QualitySettings:
     asyncUploadBufferSize: 16
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
-    customRenderPipeline: {fileID: 11400000, guid: 5e6cbd92db86f4b18aec3ed561671858,
-      type: 2}
+    customRenderPipeline: {fileID: 11400000, guid: 5e6cbd92db86f4b18aec3ed561671858, type: 2}
     terrainQualityOverrides: 0
     terrainPixelError: 1
     terrainDetailDensityScale: 1
@@ -60,7 +60,7 @@ QualitySettings:
     terrainMaxTrees: 50
     excludedTargetPlatforms:
     - Standalone
-  - serializedVersion: 4
+  - serializedVersion: 5
     name: PC
     pixelLightCount: 2
     shadows: 2
@@ -88,6 +88,7 @@ QualitySettings:
     adaptiveVsyncExtraA: 0
     adaptiveVsyncExtraB: 0
     lodBias: 2
+    meshLodThreshold: 1
     maximumLODLevel: 0
     enableLODCrossFade: 1
     streamingMipmapsActive: 0
@@ -101,8 +102,7 @@ QualitySettings:
     asyncUploadBufferSize: 16
     asyncUploadPersistentBuffer: 1
     resolutionScalingFixedDPIFactor: 1
-    customRenderPipeline: {fileID: 11400000, guid: 4b83569d67af61e458304325a23e5dfd,
-      type: 2}
+    customRenderPipeline: {fileID: 11400000, guid: 4b83569d67af61e458304325a23e5dfd, type: 2}
     terrainQualityOverrides: 0
     terrainPixelError: 1
     terrainDetailDensityScale: 1
@@ -122,6 +122,7 @@ QualitySettings:
     GameCoreXboxOne: 1
     Lumin: 0
     Nintendo Switch: 1
+    Nintendo Switch 2: 1
     PS4: 1
     PS5: 1
     Server: 0


### PR DESCRIPTION
<!--
  PR 제목 컨벤션: [Feature] / [Bug] / [Refactor] / [Chore] 접두사 사용
  예) [Feature] WASD 캐릭터 이동 구현
-->


## 관련 이슈
<!-- 자동 닫기: Closes #12 / 참고만: Refs #34 -->
Closes #70 


## 변경 사항
- BeeKingEnemy 구현: 소환/릴리즈 2가지 패턴 BT 구성
  - 패턴 0 (75%): Bee 다수 소환 → Bee King 주위 공전
  - 패턴 1 (25%, 최소 3마리 초과 시): 공전 중인 Bee 전부 플레이어 방향으로 전환 + attack 애니메이션
- BeeEnemy: ForceOrbit/ForceChase 메서드 추가, 공전 중에도 절반 탐지범위 내 플레이어 자동 추적 전환
- MonstroEnemy, BeeKingEnemy: 보스 넉백 제거


## 체크리스트
- [ ] Bee King 소환 패턴: Bee들이 Bee King 주위를 공전하는지 확인
- [ ] Bee King 릴리즈 패턴: Bee들이 플레이어를 추적하는지 확인 / attack 애니메이션 재생 확인
- [ ] 공전 중인 Bee가 탐지범위 절반 이내로 접근하면 자동으로 플레이어 추적 전환 확인
- [ ] Bee King / Monstro 피격 시 넉백 없는지 확인
- [ ] hit / die 애니메이션 정상 재생 확인
