### PR TITLE
[Feature] 플레이어 피격 시 무적시간 및 깜빡임 효과 (#80)

### DIFF
--- a/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Scripts/Player/PlayerHealth.cs
@@ -4,7 +4,7 @@ using UnityEngine;
 public class PlayerHealth : MonoBehaviour, IDamageable
 {
     [SerializeField] private int _maxHp = 6;
-    [SerializeField] private float _invincibilityDuration = 1f;
+    [SerializeField] private float _invincibilityDuration = 2f;
     [SerializeField] private float _blinkInterval = 0.1f;
 
     private int _currentHp;

--- a/Assets/Scripts/Player/PlayerHealth.cs
+++ b/Assets/Scripts/Player/PlayerHealth.cs
@@ -1,22 +1,36 @@
-using System;
+using System.Collections;
 using UnityEngine;
 
 public class PlayerHealth : MonoBehaviour, IDamageable
 {
     [SerializeField] private int _maxHp = 6;
+    [SerializeField] private float _invincibilityDuration = 1f;
+    [SerializeField] private float _blinkInterval = 0.1f;
+
     private int _currentHp;
     private bool _isProtected = false;
+    private float _invincibilityTimer;
     private PlayerAnimator playerAnimator;
+    private Renderer[] _renderers;
 
     public int MaxHp => _maxHp;
     public int CurrentHp => _currentHp;
 
+    private void Awake()
+    {
+        _renderers = GetComponentsInChildren<Renderer>();
+    }
 
     private void Start()
     {
         playerAnimator = GetComponent<PlayerAnimator>();
-
         SetMaxHp(_maxHp, true);
+    }
+
+    private void Update()
+    {
+        if (_invincibilityTimer > 0f)
+            _invincibilityTimer -= Time.deltaTime;
     }
 
     public void SetMaxHp(int newMax, bool healFull = false)
@@ -45,6 +59,8 @@ public class PlayerHealth : MonoBehaviour, IDamageable
 
     public void TakeDamage(int amount)
     {
+        if (_invincibilityTimer > 0f) return;
+
         if (_isProtected)
         {
             _isProtected = false;
@@ -57,7 +73,6 @@ public class PlayerHealth : MonoBehaviour, IDamageable
             {
                 _currentHp = 0;
                 GameEvents.OnPlayerHpChanged?.Invoke(_currentHp);
-
                 playerAnimator.PlayDie();
                 Die();
                 return;
@@ -66,7 +81,30 @@ public class PlayerHealth : MonoBehaviour, IDamageable
             playerAnimator.PlayDamage();
             GameEvents.OnPlayerHpChanged?.Invoke(_currentHp);
         }
+
+        _invincibilityTimer = _invincibilityDuration;
+        StartCoroutine(BlinkCoroutine());
         GameEvents.OnPlayerHit?.Invoke();
+    }
+
+    private IEnumerator BlinkCoroutine()
+    {
+        float elapsed = 0f;
+        while (elapsed < _invincibilityDuration)
+        {
+            SetRenderersVisible(false);
+            yield return new WaitForSeconds(_blinkInterval);
+            SetRenderersVisible(true);
+            yield return new WaitForSeconds(_blinkInterval);
+            elapsed += _blinkInterval * 2f;
+        }
+        SetRenderersVisible(true);
+    }
+
+    private void SetRenderersVisible(bool visible)
+    {
+        foreach (var r in _renderers)
+            if (r != null) r.enabled = visible;
     }
 
     public bool OnHeal(int amount)


### PR DESCRIPTION
closes #80

## Summary

- 플레이어 피격 직후 일정 시간(기본 2초) 동안 무적 상태를 부여했음
- 무적 시간 동안 Renderer를 0.1초 간격으로 토글하는 깜빡임 효과를 추가했음

## Test plan

- [ ] 피격 직후 연속 데미지가 들어오지 않는지 확인
- [ ] 무적 시간 동안 캐릭터가 깜빡이는지 확인
- [ ] 무적 시간 종료 후 정상적으로 데미지가 다시 들어오는지 확인
- [ ] _isProtected(방패) 소모 시에도 무적 타이머가 시작되는지 확인