### PR TITLE
[Feature] 플레이어 공격 사운드 및 에너미 피격 사운드 추가 (#82)

### DIFF
--- a/Assets/Prefabs/Bullet/DefaultBullet.prefab
+++ b/Assets/Prefabs/Bullet/DefaultBullet.prefab
@@ -153,3 +153,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 72d4550d85a41bf4b8a7d1107994fe5f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::DefaultBullet
+  _hitSound: {fileID: 8300000, guid: 1f18f82108b78544eb9fd2896d4b721f, type: 3}

--- a/Assets/Scripts/Bullet/BulletSpawner.cs
+++ b/Assets/Scripts/Bullet/BulletSpawner.cs
@@ -5,10 +5,21 @@ public class BulletSpawner : MonoBehaviour
     [SerializeField] private DefaultBullet _bulletPrefab;
     [SerializeField] private Transform _spawnPoint;
     [SerializeField] private LayerMask _targetLayer;
+    [SerializeField] private AudioClip _fireSound;
+
+    private AudioSource _audioSource;
+
+    private void Awake()
+    {
+        _audioSource = GetComponent<AudioSource>();
+    }
 
     public void SpawnBullet(Vector3 direction, BulletConfig config)
     {
         DefaultBullet bullet = Instantiate(_bulletPrefab, _spawnPoint.position, _spawnPoint.rotation);
         bullet.Init(_targetLayer, direction, config);
+
+        if (_fireSound != null && _audioSource != null)
+            _audioSource.PlayOneShot(_fireSound);
     }
 }

--- a/Assets/Scripts/Bullet/DefaultBullet.cs
+++ b/Assets/Scripts/Bullet/DefaultBullet.cs
@@ -4,6 +4,8 @@ using UnityEngine;
 [RequireComponent(typeof(Rigidbody))]
 public class DefaultBullet : MonoBehaviour
 {
+    [SerializeField] private AudioClip _hitSound;
+
     private LayerMask _targetLayers;
     private Rigidbody _rb;
     private BulletConfig _config;
@@ -67,6 +69,8 @@ public class DefaultBullet : MonoBehaviour
             }
             else
             {
+                if (_hitSound != null)
+                    AudioSource.PlayClipAtPoint(_hitSound, Camera.main.transform.position);
                 Destroy(gameObject);
             }
         }


### PR DESCRIPTION
closes #82

## Summary

- BulletSpawner에 AudioSource를 추가해 발사 시 공격 사운드를 재생했음
- DefaultBullet 피격 시 AudioSource.PlayClipAtPoint()로 피격 사운드를 재생했음

## Test plan

- [ ] 플레이어 발사 시 공격 사운드가 재생되는지 확인
- [ ] 적 피격 시 피격 사운드가 재생되는지 확인
- [ ] 연속 발사 시 사운드가 겹쳐 재생되는지 확인