### PR TITLE
[Feature] 이웃 방 타입에 따른 문 변형 활성화

### DIFF
--- a/Assets/Scripts/Map/DoorController.cs
+++ b/Assets/Scripts/Map/DoorController.cs
@@ -11,17 +11,37 @@ public class DoorController : MonoBehaviour
     // 개방 시 플레이어 통과를 감지하는 트리거 콜라이더 (trigger)
     [SerializeField] private Collider _triggerCollider;
 
+    [Header("Door Variants")]
+    [SerializeField] private GameObject _normalDoor;
+    [SerializeField] private GameObject _bossDoor;
+    [SerializeField] private GameObject _goldenDoor;
+
     private FloorManager _floorManager;
 
-    private void Awake()
-    {
-        gameObject.SetActive(false);
-    }
-
-    public void Init(FloorManager floorManager)
+    public void Init(FloorManager floorManager, RoomType neighborType)
     {
         _floorManager = floorManager;
+        ActivateVariant(neighborType);
         SetLocked(true);
+    }
+
+    private void ActivateVariant(RoomType neighborType)
+    {
+        // 변형이 하나만 있으면 (Door_Boss, Door_Golden 등) 그냥 켜기
+        bool hasMultipleVariants = _normalDoor != null && (_bossDoor != null || _goldenDoor != null);
+        if (!hasMultipleVariants)
+        {
+            _normalDoor?.SetActive(true);
+            _bossDoor?.SetActive(true);
+            _goldenDoor?.SetActive(true);
+            return;
+        }
+
+        bool isBoss   = neighborType == RoomType.Boss;
+        bool isGolden = neighborType == RoomType.Treasure;
+        _normalDoor.SetActive(!isBoss && !isGolden);
+        _bossDoor?.SetActive(isBoss);
+        _goldenDoor?.SetActive(isGolden);
     }
 
     public void SetLocked(bool locked)

--- a/Assets/Scripts/Map/FloorManager.cs
+++ b/Assets/Scripts/Map/FloorManager.cs
@@ -20,6 +20,16 @@ public class FloorManager : MonoBehaviour
     {
         var generator = new MapGenerator(_totalRooms);
         var nodes = generator.Generate();
+        var nodeDict = new Dictionary<Vector2Int, RoomNode>();
+        foreach (var node in nodes) nodeDict[node.GridPosition] = node;
+
+        var directions = new (Vector2Int offset, DoorFlags flag)[]
+        {
+            (Vector2Int.up,    DoorFlags.North),
+            (Vector2Int.down,  DoorFlags.South),
+            (Vector2Int.right, DoorFlags.East),
+            (Vector2Int.left,  DoorFlags.West),
+        };
 
         foreach (var node in nodes)
         {
@@ -32,7 +42,14 @@ public class FloorManager : MonoBehaviour
             var controller = instance.GetComponent<RoomController>();
             if (controller == null) continue;
 
-            controller.Init(node.GridPosition, node.DoorFlags, this);
+            var neighborTypes = new Dictionary<DoorFlags, RoomType>();
+            foreach (var (offset, flag) in directions)
+            {
+                if (nodeDict.TryGetValue(node.GridPosition + offset, out var neighbor))
+                    neighborTypes[flag] = neighbor.RoomType;
+            }
+
+            controller.Init(node.GridPosition, node.DoorFlags, this, neighborTypes);
             _rooms[node.GridPosition] = controller;
 
             if (node.RoomType == RoomType.Start)

--- a/Assets/Scripts/Map/RoomController.cs
+++ b/Assets/Scripts/Map/RoomController.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
 
+
 public class RoomController : MonoBehaviour
 {
     public Vector2Int GridPosition;
@@ -18,7 +19,7 @@ public class RoomController : MonoBehaviour
     private void OnEnable() => GameEvents.OnEnemyDead += HandleEnemyDead;
     private void OnDisable() => GameEvents.OnEnemyDead -= HandleEnemyDead;
 
-    public void Init(Vector2Int gridPosition, DoorFlags doorFlags, FloorManager floorManager)
+    public void Init(Vector2Int gridPosition, DoorFlags doorFlags, FloorManager floorManager, Dictionary<DoorFlags, RoomType> neighborTypes)
     {
         GridPosition = gridPosition;
         IsCleared = false;
@@ -27,24 +28,29 @@ public class RoomController : MonoBehaviour
             .Select(e => e.gameObject)
             .ToList();
 
+        _doorNorth?.gameObject.SetActive(false);
+        _doorSouth?.gameObject.SetActive(false);
+        _doorEast?.gameObject.SetActive(false);
+        _doorWest?.gameObject.SetActive(false);
+
         if ((doorFlags & DoorFlags.North) != 0)
         {
-            _doorNorth.Init(floorManager);
+            _doorNorth.Init(floorManager, neighborTypes.GetValueOrDefault(DoorFlags.North, RoomType.Normal));
             _doorNorth.gameObject.SetActive(true);
         }
         if ((doorFlags & DoorFlags.South) != 0)
         {
-            _doorSouth.Init(floorManager);
+            _doorSouth.Init(floorManager, neighborTypes.GetValueOrDefault(DoorFlags.South, RoomType.Normal));
             _doorSouth.gameObject.SetActive(true);
         }
         if ((doorFlags & DoorFlags.East) != 0)
         {
-            _doorEast.Init(floorManager);
+            _doorEast.Init(floorManager, neighborTypes.GetValueOrDefault(DoorFlags.East, RoomType.Normal));
             _doorEast.gameObject.SetActive(true);
         }
         if ((doorFlags & DoorFlags.West) != 0)
         {
-            _doorWest.Init(floorManager);
+            _doorWest.Init(floorManager, neighborTypes.GetValueOrDefault(DoorFlags.West, RoomType.Normal));
             _doorWest.gameObject.SetActive(true);
         }
 


### PR DESCRIPTION
## 작업 내용

- 이웃 방 타입(Normal/Boss/Golden)에 따라 문 비주얼 변형을 활성화하는 기능을 구현했음
- `FloorManager`에서 각 방의 이웃 타입 딕셔너리를 생성해 `RoomController` → `DoorController`로 전달했음
- `DoorController`에 `_normalDoor` / `_bossDoor` / `_goldenDoor` 필드를 추가하고 `ActivateVariant()` 로직을 구현했음
- `Door_Boss` / `Door_Golden` 프리팹이 `m_IsActive: 0`으로 시작해 `SetActive(true)` 시점에 `Awake()`가 처음 실행되며 문이 꺼지던 타이밍 버그를 수정했음

## 버그 원인

`Door_Normal`은 `m_IsActive: 1`로 시작해 Instantiate 시점에 `Awake()`가 즉시 실행됨.  
반면 `Door_Boss` / `Door_Golden`은 `m_IsActive: 0`으로 시작해 `Awake()`가 지연되고, `RoomController.Init()`이 `SetActive(true)`를 호출하는 순간 처음 실행되어 바로 `SetActive(false)`로 문을 꺼버렸음.

→ `DoorController.Awake()` 제거, `RoomController.Init()` 상단에서 모든 문을 명시적으로 비활성화하도록 수정했음.

closes #89