### PR TITLE
[Feature] RoomData Weight 기반 가중치 랜덤 방 선택 및 보스 참조 구조 추가

### DIFF
--- a/Assets/Scripts/Map/FloorManager.cs
+++ b/Assets/Scripts/Map/FloorManager.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
 public class FloorManager : MonoBehaviour
@@ -10,6 +11,9 @@ public class FloorManager : MonoBehaviour
     private Dictionary<Vector2Int, RoomController> _rooms = new();
     private RoomController _currentRoom;
     public RoomController CurrentRoom => _currentRoom;
+
+    private EnemyBase _boss;
+    public EnemyBase Boss => _boss;
 
     private void Start()
     {
@@ -51,6 +55,9 @@ public class FloorManager : MonoBehaviour
 
             controller.Init(node.GridPosition, node.DoorFlags, this, neighborTypes);
             _rooms[node.GridPosition] = controller;
+
+            if (node.RoomType == RoomType.Boss)
+                _boss = controller.Boss;
 
             if (node.RoomType == RoomType.Start)
                 ActivateRoom(controller);
@@ -114,7 +121,21 @@ public class FloorManager : MonoBehaviour
 
     private RoomData GetRoomData(RoomType type)
     {
-        return _roomDataList.Find(d => d.RoomType == type)
-            ?? _roomDataList.Find(d => d.RoomType == RoomType.Normal);
+        var candidates = _roomDataList.Where(d => d.RoomType == type).ToList();
+        if (candidates.Count == 0)
+            candidates = _roomDataList.Where(d => d.RoomType == RoomType.Normal).ToList();
+        if (candidates.Count == 0) return null;
+
+        int totalWeight = candidates.Sum(d => d.Weight);
+        if (totalWeight <= 0) return candidates[0];
+
+        int roll = Random.Range(0, totalWeight);
+        int cumulative = 0;
+        foreach (var data in candidates)
+        {
+            cumulative += data.Weight;
+            if (roll < cumulative) return data;
+        }
+        return candidates[^1];
     }
 }

--- a/Assets/Scripts/Map/RoomController.cs
+++ b/Assets/Scripts/Map/RoomController.cs
@@ -13,6 +13,9 @@ public class RoomController : MonoBehaviour
     [SerializeField] private DoorController _doorEast;
     [SerializeField] private DoorController _doorWest;
 
+    [SerializeField] private EnemyBase _boss;
+    public EnemyBase Boss => _boss;
+
     private List<GameObject> _enemies = new();
     private bool _isActive;
 


### PR DESCRIPTION
## 작업 내용

- `GetRoomData()`를 같은 `RoomType` 항목들의 `Weight` 비율로 가중치 랜덤 선택하도록 변경했음
- `RoomController`에 `[SerializeField] EnemyBase _boss` 필드를 추가했음 (인스펙터에서 직접 할당, 런타임 GO 탐색 없음)
- `FloorManager`에 `Boss` 프로퍼티를 추가하여 UI 담당자가 `FloorManager.Boss`로 보스의 `CurrentHp` / `maxHp`에 접근할 수 있는 구조를 마련했음

## 사용 방법

- 같은 `RoomType`의 프리팹을 여러 개 등록하고 `Weight`로 비율 조정 가능 (예: Normal 3개에 3:2:1 설정)
- Boss 방 프리팹을 여러 개 등록하면 `Weight` 비율에 따라 하나만 랜덤 선택됨
- Boss 방 프리팹 편집 모드에서 보스 자식 오브젝트를 `RoomController._boss` 슬롯에 할당해야 함

closes #91